### PR TITLE
refactor: set OASF_API_VALIDATION_SCHEMA_URL default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,11 +393,10 @@ If you prefer shorter-lived credentials, you can use OAuth tokens obtained via `
 #### OASF Validation Configuration
 
 - `OASF_API_VALIDATION_SCHEMA_URL` - OASF schema URL for validation and schema operations
-  - **Required** - The MCP server requires this environment variable to be set
+  - **Optional** - Defaults to `https://schema.oasf.outshift.com`
   - URL of the OASF schema server to use for validation and schema retrieval
-  - If not set, the server will fail to start with an error
-  - Example: `https://schema.oasf.outshift.com`
-  
+  - Override only when you need to point at a self-hosted or alternate OASF schema server
+
   This URL is used for:
   - Validating OASF agent records
   - Retrieving schema content, versions, skills, and domains
@@ -412,7 +411,6 @@ If you prefer shorter-lived credentials, you can use OAuth tokens obtained via `
       "command": "/absolute/path/to/dirctl",
       "args": ["mcp", "serve"],
       "env": {
-        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
         "DIRECTORY_CLIENT_SERVER_ADDRESS": "localhost:8888"
       }
     }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,8 +44,6 @@ tasks:
   test:e2e:
     desc: Run e2e tests
     dir: tests/e2e
-    env:
-      OASF_API_VALIDATION_SCHEMA_URL: '{{ .OASF_API_VALIDATION_SCHEMA_URL | default "https://schema.oasf.outshift.com" }}'
     cmds:
       - go test -v -timeout 5m ./...
 

--- a/docs/directory-mcp.md
+++ b/docs/directory-mcp.md
@@ -18,7 +18,7 @@ The MCP server runs via the `dirctl` CLI tool and acts as a bridge between AI de
 
 Add the MCP server to your IDE's MCP configuration using the absolute path to the `dirctl` binary.
 
-The server requires `OASF_API_VALIDATION_SCHEMA_URL` (see [Environment variables](#environment-variables)); without it the process exits on startup.
+The server uses `https://schema.oasf.outshift.com` as the default OASF schema server. Override it with `OASF_API_VALIDATION_SCHEMA_URL` (see [Environment variables](#environment-variables)) only when you need to target a self-hosted or alternate OASF schema server.
 
 **Example Cursor configuration (`~/.cursor/mcp.json`):**
 
@@ -27,10 +27,7 @@ The server requires `OASF_API_VALIDATION_SCHEMA_URL` (see [Environment variables
   "mcpServers": {
     "dir-mcp-server": {
       "command": "/absolute/path/to/dirctl",
-      "args": ["mcp", "serve"],
-      "env": {
-        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
-      }
+      "args": ["mcp", "serve"]
     }
   }
 }
@@ -38,7 +35,7 @@ The server requires `OASF_API_VALIDATION_SCHEMA_URL` (see [Environment variables
 
 ### Docker Configuration
 
-Add the MCP server to your IDE's MCP configuration using Docker. Pass the same schema URL via `--env` (the container does not set a default).
+Add the MCP server to your IDE's MCP configuration using Docker.
 
 ??? example "Example Cursor configuration (`~/.cursor/mcp.json`)"
 
@@ -51,8 +48,6 @@ Add the MCP server to your IDE's MCP configuration using Docker. Pass the same s
             "run",
             "--rm",
             "-i",
-            "--env",
-            "OASF_API_VALIDATION_SCHEMA_URL=https://schema.oasf.outshift.com",
             "ghcr.io/agntcy/dir-ctl:latest",
             "mcp",
             "serve"
@@ -66,7 +61,7 @@ Add the MCP server to your IDE's MCP configuration using Docker. Pass the same s
 
 Configure the MCP server behavior using environment variables:
 
-- `OASF_API_VALIDATION_SCHEMA_URL` - Required. Base URL of the OASF schema API used to load schemas for validation (for example `https://schema.oasf.outshift.com`). The server will not start if this is unset.
+- `OASF_API_VALIDATION_SCHEMA_URL` - Optional. Base URL of the OASF schema API used to load schemas for validation. Defaults to `https://schema.oasf.outshift.com`. Override only when you need to point at a self-hosted or alternate OASF schema server.
 - `DIRECTORY_CLIENT_SERVER_ADDRESS` - Directory server address (default: `0.0.0.0:8888`)
 - `DIRECTORY_CLIENT_AUTH_MODE` - Authentication mode: `none`, `x509`, `jwt`, `token`
 - `DIRECTORY_CLIENT_SPIFFE_TOKEN` - Path to SPIFFE token file (for token authentication)

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,16 +15,22 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// defaultOASFSchemaURL is used when OASF_API_VALIDATION_SCHEMA_URL is not set.
+// Users can override it by exporting OASF_API_VALIDATION_SCHEMA_URL before
+// starting the MCP server (e.g. to point at a self-hosted OASF schema server).
+const defaultOASFSchemaURL = "https://schema.oasf.outshift.com"
+
 // Serve creates and runs the MCP server with all configured tools and prompts.
 // It accepts a context and runs the server over stdin/stdout using the stdio transport.
 //
 //nolint:maintidx // Function registers all MCP tools and prompts, complexity is acceptable
 func Serve(ctx context.Context) error {
-	// Configure OASF validation.
-	// Schema URL is required for OASF validation.
+	// Resolve the OASF schema URL once: explicit env var wins, otherwise
+	// fall back to the default public OASF schema server. This URL is
+	// shared by the OASF validator and the schema-related MCP tools.
 	schemaURL := os.Getenv("OASF_API_VALIDATION_SCHEMA_URL")
 	if schemaURL == "" {
-		return errors.New("OASF_API_VALIDATION_SCHEMA_URL environment variable is required. Set it to the OASF schema URL (e.g., https://schema.oasf.outshift.com)")
+		schemaURL = defaultOASFSchemaURL
 	}
 
 	// Construct the OASF validator once at process startup and inject it
@@ -37,7 +42,7 @@ func Serve(ctx context.Context) error {
 	}
 
 	// Create Directory client tools (shared client for all tool calls)
-	t, err := tools.NewTools(ctx, oasfValidator)
+	t, err := tools.NewTools(ctx, oasfValidator, schemaURL)
 	if err != nil {
 		return fmt.Errorf("failed to create Directory client: %w", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServe_ValidationConfiguration(t *testing.T) {
@@ -47,7 +48,7 @@ func TestServe_ValidationConfiguration(t *testing.T) {
 			// We expect an error from the cancelled context rather than a
 			// configuration error. The previous behavior of erroring on an
 			// unset env var is no longer expected.
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.NotContains(t, err.Error(), "OASF_API_VALIDATION_SCHEMA_URL",
 				"Serve should no longer require OASF_API_VALIDATION_SCHEMA_URL")
 		})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,65 +8,48 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestServe_ValidationConfiguration(t *testing.T) {
 	tests := []struct {
 		name             string
 		oasfSchemaURLEnv string
-		wantError        bool // If true, expects Serve to return an error (configuration error)
 	}{
 		{
-			name:             "error when schema URL is not set",
+			name:             "falls back to default schema URL when env is not set",
 			oasfSchemaURLEnv: "",
-			wantError:        true, // Should error because schema URL is required
 		},
 		{
 			name:             "use schema URL from OASF_API_VALIDATION_SCHEMA_URL env",
 			oasfSchemaURLEnv: "https://schema.oasf.outshift.com",
-			wantError:        false,
 		},
 		{
 			name:             "use custom schema URL",
 			oasfSchemaURLEnv: "https://custom.schema.url",
-			wantError:        false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set test env vars. The validator is constructed inside Serve
-			// from this value, so no global initialization is required.
-			if tt.oasfSchemaURLEnv != "" {
-				t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", tt.oasfSchemaURLEnv)
-			} else {
-				// Clear env var to test error behavior
-				t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "")
-			}
+			// The validator is constructed inside Serve from this value, so
+			// no global initialization is required.
+			t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", tt.oasfSchemaURLEnv)
 
 			// Create a context that will be cancelled immediately to stop Serve early
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // Cancel immediately so Serve returns quickly
 
-			// Call Serve - it will configure validation and then return due to cancelled context
+			// Call Serve - it will configure validation and then return due
+			// to cancelled context. Serve should not return a configuration
+			// error: an empty env var must fall back to the default URL.
 			err := Serve(ctx)
 
-			if tt.wantError {
-				// Verify that Serve returned a configuration error
-				require.Error(t, err, "Serve should return error when schema URL is missing")
-				assert.Contains(t, err.Error(), "OASF_API_VALIDATION_SCHEMA_URL", "Error should mention OASF_API_VALIDATION_SCHEMA_URL")
-			} else {
-				// Verify that validation was configured correctly
-				// We can't directly check the internal state, but we can verify
-				// that the configuration functions were called by checking if
-				// validation still works with the expected settings
-				assert.Error(t, err) // Should error due to cancelled context (not configuration error)
-
-				// Note: We can't easily verify the exact configuration without
-				// exposing internal state, but the fact that Serve runs without
-				// panicking and configures the validators is sufficient coverage
-			}
+			// We expect an error from the cancelled context rather than a
+			// configuration error. The previous behavior of erroring on an
+			// unset env var is no longer expected.
+			assert.Error(t, err)
+			assert.NotContains(t, err.Error(), "OASF_API_VALIDATION_SCHEMA_URL",
+				"Serve should no longer require OASF_API_VALIDATION_SCHEMA_URL")
 		})
 	}
 }

--- a/tools/get_schema.go
+++ b/tools/get_schema.go
@@ -34,12 +34,12 @@ func (t *Tools) GetSchema(ctx context.Context, _ *mcp.CallToolRequest, input Get
 	error,
 ) {
 	// Get schema instance
-	schemaInstance, err := getSchemaInstance()
+	schemaInstance, err := t.getSchemaInstance()
 	if err != nil {
 		// Try to get available versions for error message
 		var availableVersions []string
 
-		if inst, getErr := getSchemaInstance(); getErr == nil {
+		if inst, getErr := t.getSchemaInstance(); getErr == nil {
 			if versions, getVersErr := inst.GetAvailableSchemaVersions(ctx); getVersErr == nil {
 				availableVersions = versions
 			}

--- a/tools/get_schema_domains.go
+++ b/tools/get_schema_domains.go
@@ -43,7 +43,7 @@ func (t *Tools) GetSchemaDomains(ctx context.Context, _ *mcp.CallToolRequest, in
 	GetSchemaDomainsOutput,
 	error,
 ) {
-	availableVersions, err := validateVersion(ctx, input.Version)
+	availableVersions, err := t.validateVersion(ctx, input.Version)
 	if err != nil {
 		//nolint:nilerr // MCP tools communicate errors through output, not error return
 		return nil, GetSchemaDomainsOutput{
@@ -53,7 +53,7 @@ func (t *Tools) GetSchemaDomains(ctx context.Context, _ *mcp.CallToolRequest, in
 	}
 
 	// Get schema instance
-	schemaInstance, err := getSchemaInstance()
+	schemaInstance, err := t.getSchemaInstance()
 	if err != nil {
 		//nolint:nilerr // MCP tools communicate errors through output, not error return
 		return nil, GetSchemaDomainsOutput{

--- a/tools/get_schema_domains_test.go
+++ b/tools/get_schema_domains_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetSchemaDomains(t *testing.T) {
 	ctx := context.Background()
 	// Create Tools instance (nil client is fine - GetSchemaDomains doesn't use client)
-	tools := &Tools{Client: nil}
+	tools := &Tools{Client: nil, SchemaURL: "https://schema.oasf.outshift.com"}
 
 	tests := []struct {
 		name          string
@@ -115,9 +115,6 @@ func TestGetSchemaDomains(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
-			// Note: t.Setenv cannot be used with t.Parallel(), so we run tests sequentially
-
 			result, output, err := tools.GetSchemaDomains(ctx, nil, tt.input)
 
 			if tt.expectError {

--- a/tools/get_schema_skills.go
+++ b/tools/get_schema_skills.go
@@ -43,7 +43,7 @@ func (t *Tools) GetSchemaSkills(ctx context.Context, _ *mcp.CallToolRequest, inp
 	GetSchemaSkillsOutput,
 	error,
 ) {
-	availableVersions, err := validateVersion(ctx, input.Version)
+	availableVersions, err := t.validateVersion(ctx, input.Version)
 	if err != nil {
 		//nolint:nilerr // MCP tools communicate errors through output, not error return
 		return nil, GetSchemaSkillsOutput{
@@ -53,7 +53,7 @@ func (t *Tools) GetSchemaSkills(ctx context.Context, _ *mcp.CallToolRequest, inp
 	}
 
 	// Get schema instance
-	schemaInstance, err := getSchemaInstance()
+	schemaInstance, err := t.getSchemaInstance()
 	if err != nil {
 		//nolint:nilerr // MCP tools communicate errors through output, not error return
 		return nil, GetSchemaSkillsOutput{

--- a/tools/get_schema_skills_test.go
+++ b/tools/get_schema_skills_test.go
@@ -13,11 +13,9 @@ import (
 )
 
 func TestGetSchemaSkills(t *testing.T) {
-	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
-
 	ctx := context.Background()
 	// Create Tools instance (nil client is fine - GetSchemaSkills doesn't use client)
-	tools := &Tools{Client: nil}
+	tools := &Tools{Client: nil, SchemaURL: "https://schema.oasf.outshift.com"}
 
 	tests := []struct {
 		name          string
@@ -117,9 +115,6 @@ func TestGetSchemaSkills(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
-			// Note: t.Setenv cannot be used with t.Parallel(), so we run tests sequentially
-
 			result, output, err := tools.GetSchemaSkills(ctx, nil, tt.input)
 
 			if tt.expectError {

--- a/tools/get_schema_test.go
+++ b/tools/get_schema_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 func TestGetSchema(t *testing.T) {
-	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
-
 	// Create Tools instance (nil client is fine - GetSchema doesn't use client)
-	tools := &Tools{Client: nil}
+	tools := &Tools{Client: nil, SchemaURL: "https://schema.oasf.outshift.com"}
 
 	t.Run("should return schema for valid version", func(t *testing.T) {
 		ctx := context.Background()

--- a/tools/list_versions.go
+++ b/tools/list_versions.go
@@ -31,7 +31,7 @@ func (t *Tools) ListVersions(ctx context.Context, _ *mcp.CallToolRequest, _ List
 	error,
 ) {
 	// Get schema instance
-	schemaInstance, err := getSchemaInstance()
+	schemaInstance, err := t.getSchemaInstance()
 	if err != nil {
 		return nil, ListVersionsOutput{
 			ErrorMessage: fmt.Sprintf("Failed to initialize schema client: %v", err),

--- a/tools/list_versions_test.go
+++ b/tools/list_versions_test.go
@@ -17,11 +17,8 @@ func contains(slice []string, item string) bool {
 }
 
 func TestListVersions(t *testing.T) {
-	// ListVersions doesn't require schema URL, but set it for consistency
-	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
-
 	// Create Tools instance (nil client is fine - ListVersions doesn't use client)
-	tools := &Tools{Client: nil}
+	tools := &Tools{Client: nil, SchemaURL: "https://schema.oasf.outshift.com"}
 
 	t.Run("should return available versions", func(t *testing.T) {
 		ctx := context.Background()

--- a/tools/schema_helpers.go
+++ b/tools/schema_helpers.go
@@ -6,50 +6,42 @@ package tools
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/agntcy/oasf-sdk/pkg/schema"
 )
 
-var (
-	schemaInstance *schema.Schema
-	schemaMu       sync.Mutex
-	schemaURL      string
-)
+// getSchemaInstance returns a lazily-initialized Schema instance using the
+// SchemaURL configured on the Tools struct. The instance is created on first
+// use and cached for subsequent calls. The schema URL is resolved once at
+// server startup (see server.Serve) and remains immutable for the process
+// lifetime.
+func (t *Tools) getSchemaInstance() (*schema.Schema, error) {
+	t.schemaMu.Lock()
+	defer t.schemaMu.Unlock()
 
-// getSchemaInstance returns a Schema instance initialized from environment variable.
-// It checks the environment variable each time to support test scenarios.
-func getSchemaInstance() (*schema.Schema, error) {
-	schemaMu.Lock()
-	defer schemaMu.Unlock()
-
-	currentSchemaURL := os.Getenv("OASF_API_VALIDATION_SCHEMA_URL")
-	if currentSchemaURL == "" {
-		return nil, fmt.Errorf("OASF_API_VALIDATION_SCHEMA_URL environment variable is required. Set it to the OASF schema URL (e.g., https://schema.oasf.outshift.com)")
+	if t.SchemaURL == "" {
+		return nil, fmt.Errorf("schema URL is not configured")
 	}
 
-	// If schema URL changed or instance is nil, create a new instance
-	if schemaInstance == nil || schemaURL != currentSchemaURL {
-		var err error
-
-		schemaInstance, err = schema.New(currentSchemaURL, schema.WithCache(true))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create schema instance: %w", err)
-		}
-
-		schemaURL = currentSchemaURL
+	if t.schemaInstance != nil {
+		return t.schemaInstance, nil
 	}
 
-	return schemaInstance, nil
+	inst, err := schema.New(t.SchemaURL, schema.WithCache(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create schema instance: %w", err)
+	}
+
+	t.schemaInstance = inst
+
+	return t.schemaInstance, nil
 }
 
 // validateVersion checks if the provided version is valid and returns available versions.
-func validateVersion(ctx context.Context, version string) ([]string, error) {
-	// Get schema instance to fetch available versions
-	schemaInstance, err := getSchemaInstance()
+func (t *Tools) validateVersion(ctx context.Context, version string) ([]string, error) {
+	schemaInstance, err := t.getSchemaInstance()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize schema client: %w", err)
 	}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -6,9 +6,11 @@ package tools
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/client"
+	"github.com/agntcy/oasf-sdk/pkg/schema"
 )
 
 // Tools provides Directory client-dependent tool implementations.
@@ -18,17 +20,26 @@ import (
 // (e.g. PushRecord, ValidateRecord). It is injected by the caller (the
 // MCP server entrypoint) so that no process-wide singleton is needed
 // and so that tests can supply fakes. See github.com/agntcy/dir issue #856.
+//
+// SchemaURL is the OASF schema API URL used by schema-related tools
+// (e.g. GetSchema, ListVersions). It is resolved once at server startup
+// from the OASF_API_VALIDATION_SCHEMA_URL environment variable (with a
+// default fallback) and remains immutable for the process lifetime.
 type Tools struct {
 	Client        *client.Client
 	ServerAddress string
 	Validator     corev1.Validator
+	SchemaURL     string
+
+	schemaMu       sync.Mutex
+	schemaInstance *schema.Schema
 }
 
-// NewTools creates a new Tools instance with a Directory client and the
-// provided OASF validator. The caller is responsible for calling Close()
+// NewTools creates a new Tools instance with a Directory client, OASF
+// validator, and schema URL. The caller is responsible for calling Close()
 // when done. The validator is owned by the caller; Close() does not
 // touch it.
-func NewTools(ctx context.Context, validator corev1.Validator) (*Tools, error) {
+func NewTools(ctx context.Context, validator corev1.Validator, schemaURL string) (*Tools, error) {
 	config, err := client.LoadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load client configuration: %w", err)
@@ -43,6 +54,7 @@ func NewTools(ctx context.Context, validator corev1.Validator) (*Tools, error) {
 		Client:        c,
 		ServerAddress: config.ServerAddress,
 		Validator:     validator,
+		SchemaURL:     schemaURL,
 	}, nil
 }
 


### PR DESCRIPTION
Default `OASF_API_VALIDATION_SCHEMA_URL` to `https://schema.oasf.outshift.com` so the MCP server starts out-of-the-box. Env var still wins when set.

closes: https://github.com/agntcy/dir-mcp/issues/16